### PR TITLE
[hotfix-EPSQD-035] - Corregir error en login

### DIFF
--- a/backend/app/controllers/user.js
+++ b/backend/app/controllers/user.js
@@ -122,10 +122,6 @@ exports.updateOne = async (req, res) => {
         const { id } = req.params;
         const body = req.body;
 
-        if (body.password) {
-            body.password = await bcrypt.hash(body.password, 10);
-        }
-
         const updatedUser = await User.findOneAndUpdate({ _id: id }, { $set: body }, { new: true });
 
         if (!updatedUser) {


### PR DESCRIPTION
### SUMMARY
Trello ticket: https://trello.com/c/91pVh2Km/112-hotfix-epsqd-035-corregir-error-en-login

> En el updateOne del controller.js del user debe estar el error.
> Ahí no debemos hacer hash de la contraseña, para eso ya tenemos otra función de actualizar contraseña cuando se necesite.

### Expected behaviour

Ya no debería dar errores el login después de haber actualizado el usuario de alguna manera (por ejemplo, añadiendo algún alta al user, pagando el abono...)

### Before Screenshots


### After Screenshots

