### PR TITLE
[DPURJC-041] - Persistencia de datos del user en cookies

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -5,10 +5,10 @@ const cors = require('cors');
 const mailsRouters = require('./app/routes/mail');
 
 const app = express();
-const port = process.env.PORT;
+const port = process.env.BACKEND_PORT;
 
 app.use(cors({
-    origin: ['http://localhost:8080'],
+    origin: [process.env.FRONTEND_URL],
     credentials: true
 }));
 
@@ -22,7 +22,7 @@ app.use(session({
     resave: false,
     saveUninitialized: false,
     cookie: {
-        secure: false, // TODO: change to true in production (HTTPS: process.env.NODE_ENV === 'production')
+        secure: process.env.NODE_ENV === 'production', // Use secure cookies in production
         httpOnly: true,
         maxAge: 60 * 60 * 1000 // 1 hour
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "bson": "^6.10.1",
         "dotenv": "^16.4.5",
+        "js-cookie": "^3.0.5",
         "react": "18.3.1",
         "react-datepicker": "^6.9.0",
         "react-dom": "18.3.1",
@@ -28,7 +29,6 @@
         "@types/react-dom": "^18.2.22",
         "@vitejs/plugin-react-swc": "^3.5.0",
         "babel-jest": "^29.7.0",
-        "cross-env": "^7.0.3",
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -4686,25 +4686,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -7737,6 +7718,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "bson": "^6.10.1",
     "dotenv": "^16.4.5",
+    "js-cookie": "^3.0.5",
     "react": "18.3.1",
     "react-datepicker": "^6.9.0",
     "react-dom": "18.3.1",

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,14 +1,25 @@
 import {
     createContext,
     useState,
-    useContext
+    useContext,
+    useEffect
 } from "react";
+import Cookies from 'js-cookie';
 
 const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
     const [user, setUser] = useState(null);
     const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+    useEffect(() => {
+        const cookieUser = Cookies.get('user');
+        if (cookieUser && !user) {
+            const parsed = JSON.parse(cookieUser);
+            setUser(parsed);
+            setIsAuthenticated(true);
+        }
+    }, []);
 
     const getAllUsers = async () => {
         try {
@@ -50,6 +61,7 @@ export const AuthProvider = ({ children }) => {
                 const loggedInUser = await response.json();
                 setUser(loggedInUser);
                 setIsAuthenticated(true);
+                Cookies.set('user', JSON.stringify(loggedInUser), { expires: 7 }); // Set cookie with user data for 7 days
                 navigate("/");
                 return response;
             } else {
@@ -106,6 +118,7 @@ export const AuthProvider = ({ children }) => {
             if (response.ok) {
                 setUser(null);
                 setIsAuthenticated(false);
+                Cookies.remove('user');
             } else {
                 console.error("Error al cerrar sesión:", response.status);
             }

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -142,7 +142,7 @@ export const AuthProvider = ({ children }) => {
             if (response.ok) {
                 const updatedUser = await response.json();
                 if (user?._id === userId) {
-                    setUser(updatedUser);
+                    updateUserAndCookie(updatedUser);
                 }
                 return response;
             } else {
@@ -167,12 +167,12 @@ export const AuthProvider = ({ children }) => {
             });
     
             const data = await response.json();
-    
+
             if (!response.ok) {
                 throw new Error(data.message || "Error al actualizar el perfil");
             }
     
-            setUser(data.user);
+            updateUserAndCookie(data.user);
             return data.user;
     
         } catch (error) {
@@ -247,6 +247,11 @@ export const AuthProvider = ({ children }) => {
         }
     };
 
+    const updateUserAndCookie = (updatedUser) => {
+        setUser(updatedUser);
+        Cookies.set('user', JSON.stringify(updatedUser), { expires: 7 });
+    };
+
     return (
         <AuthContext.Provider value={{
             user,
@@ -261,7 +266,8 @@ export const AuthProvider = ({ children }) => {
             isAdmin,
             isStudent,
             handleAdmin,
-            updatePasswordAndName
+            updatePasswordAndName,
+            updateUserAndCookie
         }}>
         {children}
         </AuthContext.Provider>

--- a/frontend/src/context/TeamsAndResultsContext.test.js
+++ b/frontend/src/context/TeamsAndResultsContext.test.js
@@ -56,7 +56,7 @@ describe("TeamsAndResultsProvider", () => {
 
             await waitFor(() => {
                 expect(fetch).toHaveBeenCalledTimes(3);
-                expect(fetch).toHaveBeenCalledWith("http://localhost:4000teams");
+                expect(fetch).toHaveBeenCalledWith("http://localhost:4000/teams");
                 expect(contextValues.teams).toEqual(mockTeams);
                 expect(fetchedTeams).toEqual(mockTeams);
             });

--- a/frontend/src/utils/mocks.js
+++ b/frontend/src/utils/mocks.js
@@ -1,8 +1,15 @@
 export const mockAuthContext = {
     user: null,
     isAuthenticated: false,
+    setUser: jest.fn((newUser) => {
+        mockAuthContext.user = newUser;
+    }),
+    updateUserAndCookie: jest.fn((updatedUser) => {
+        mockAuthContext.user = updatedUser;
+    }),
     login: jest.fn().mockImplementation(async (credentials, callback) => {
-        mockAuthContext.user = { _id: "123", email: credentials.email, role: "admin" };
+        const mockUser = { _id: "123", email: credentials.email, role: "admin" };
+        mockAuthContext.user = mockUser;
         mockAuthContext.isAuthenticated = true;
         if (callback) callback();
     }),
@@ -15,16 +22,25 @@ export const mockAuthContext = {
         { _id: "2", email: "user2@admin.com", role: "admin" }
     ]),
     addUser: jest.fn().mockResolvedValue({ _id: "3", email: "newuser@test.com", role: "user" }),
-    updateUser: jest.fn().mockResolvedValue({ _id: "123", email: "updated@test.com" }),
-    updatePasswordAndName: jest.fn((userId, newPassword, newName) => {
-        return Promise.resolve({ success: true, userId, newPassword, newName });
+    updateUser: jest.fn().mockImplementation(async (id, data) => {
+        if (mockAuthContext.user?._id === id) {
+            const updated = { ...mockAuthContext.user, ...data };
+            mockAuthContext.updateUserAndCookie(updated);
+            return updated;
+        }
+        return { _id: id, ...data };
+    }),
+    updatePasswordAndName: jest.fn().mockImplementation(async (id, currentPassword, newPassword, name) => {
+        const updated = { ...mockAuthContext.user, name };
+        mockAuthContext.updateUserAndCookie(updated);
+        return updated;
     }),
     deleteUser: jest.fn().mockResolvedValue(true),
     isAdmin: jest.fn(() => mockAuthContext.user?.role === "admin"),
-    isStudent: jest.fn(() => mockAuthContext.user?.role === "student"),
+    isStudent: jest.fn(() => mockAuthContext.user?.email.includes("@alumnos.urjc.es")),
     handleAdmin: jest.fn().mockResolvedValue(true),
-    setUser: jest.fn(),
 };
+
 
 export const mockFacilitiesAndReservationsContext = {
     facilities: [{ _id: '1', name: 'Gimnasio' }],

--- a/frontend/src/views/profile/seeProfile/SeeProfile.jsx
+++ b/frontend/src/views/profile/seeProfile/SeeProfile.jsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { useFacilitiesAndReservations } from "../../../context/FacilitiesAndReservationsContext";
 
 const SeeProfile = () => {
-    const { user, setUser, isAdmin, logout, deleteUser, updatePasswordAndName } = useAuth();
+    const { user, updateUserAndCookie, isAdmin, logout, deleteUser, updatePasswordAndName } = useAuth();
     const { reservations, deleteReservation } = useFacilitiesAndReservations();
     const navigate = useNavigate();
     const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
@@ -63,9 +63,6 @@ const SeeProfile = () => {
                 return;
             }
             toast.success("Perfil actualizado con éxito.");
-
-            const { user: updatedUser } = updatedUserRes;
-            await setUser(updatedUser);
             setEditMode(false);
         } catch (error) {
             console.error("Error al actualizar el perfil:", error);

--- a/frontend/src/views/profile/seeProfile/SeeProfile.test.js
+++ b/frontend/src/views/profile/seeProfile/SeeProfile.test.js
@@ -39,6 +39,7 @@ describe("SeeProfile Component", () => {
         mockAuthContext.updateUser.mockResolvedValue({ status: 200, data: { message: 'Profile updated' } });
         mockFacilitiesAndReservationsContext.reservations = [];
         mockFacilitiesAndReservationsContext.deleteReservation.mockResolvedValue({ status: 200 });
+        mockAuthContext.updateUserAndCookie = jest.fn();
     });
 
     it("renders component with user data", () => {
@@ -79,7 +80,7 @@ describe("SeeProfile Component", () => {
         expect(passwordInput.value).toBe("newPass123");
     });
 
-    it("calls updateUser and shows success message on valid edit form submission", async () => {
+    it("calls updatePasswordAndName and updateUserAndCookie on valid edit form submission", async () => {
         render(<SeeProfile />);
         const editButton = screen.getByRole("button", { name: /editar perfil/i });
         fireEvent.click(editButton);
@@ -96,6 +97,7 @@ describe("SeeProfile Component", () => {
 
         await waitFor(() => {
             expect(mockAuthContext.updatePasswordAndName).toHaveBeenCalledWith("123", "actualPass", "updatedPass", "Updated Name");
+            expect(mockAuthContext.updateUserAndCookie).toHaveBeenCalledWith(expect.objectContaining({ name: "Updated Name" }));
             expect(toast.success).toHaveBeenCalledWith("Perfil actualizado con éxito.");
         });
     });
@@ -109,7 +111,6 @@ describe("SeeProfile Component", () => {
 
         await waitFor(() => {
             expect(toast.error).toHaveBeenCalledWith("El nombre y la contraseña no pueden estar vacíos.");
-            expect(mockAuthContext.updateUser).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
### SUMMARY
Trello ticket: https://trello.com/c/QpDPGhPv/46-dpurjc-041-persistencia-de-datos-del-user-en-cookies

> Se necesita que al iniciar sesión (o registrarse) un usuario, parte de la información del usuario se guarde en cookies para persistencia entre sesiones (por ejemplo: token, nombre, rol...).
> 
> Además, es necesario refactorizar las variables del .env para los puertos y urls, donde se utilicen. De tal manera, que cuando se quiera desplegar la app en producción, esté todo montado para que únicamente haya que tocar el .env

### Expected behaviour

Al iniciar sesión se debe guardar la info del user en las cookies (toda la info menos la contraseña).
Además, cuando se edite un usuario o se actualicen datos suyos, se deben guardar en las cookies también (como las suscripciones...)

### Before Screenshots
![image](https://github.com/user-attachments/assets/e8c7ffdc-db88-42e1-81c4-9a9b3d37e603)


### After Screenshots
![image](https://github.com/user-attachments/assets/fdf3d57a-c976-4967-96c6-324aaed1890e)

