### PR TITLE
[DPURJC-043]: Mejoras en visualización de resultados, navegación y restricciones de reserva

### DIFF
--- a/backend/app/controllers/reservation.js
+++ b/backend/app/controllers/reservation.js
@@ -24,8 +24,6 @@ exports.insertData = async (req, res) => {
             isPaid
         });
 
-        console.log('---newReserva---', newReserva);
-
         const savedReservation = await newReserva.save();
         res.status(201).json(savedReservation);
 

--- a/backend/app/controllers/team.js
+++ b/backend/app/controllers/team.js
@@ -24,10 +24,7 @@ exports.updateOne = async (req, res) => {
         const { id } = req.params;
         const body = req.body;
 
-        console.log('---body---', body);
-        console.log('---id---', id);
         const updateTeam = await Team.updateOne({ _id: id }, { $set: body });
-        console.log('---updateTeam---', updateTeam);
 
         if (updateTeam.matchedCount === 0) {
             res.status(404).json({ message: 'No se encontró el equipo para actualizar' });

--- a/frontend/src/components/ContentAdminPanel/ContentAdminPanel.jsx
+++ b/frontend/src/components/ContentAdminPanel/ContentAdminPanel.jsx
@@ -2,7 +2,6 @@ import { Fragment } from "react";
 import { Link } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import "./ContentAdminPanel.css";
-import BackButton from "../../components/backButton/BackButton";
 import AccessDenied from "../accessDenied/AccessDenied";
 
 const ContentAdminPanel = () => {
@@ -13,7 +12,6 @@ const ContentAdminPanel = () => {
             {user && isAdmin() ? (
                 <div id="component-content">
                     <div className="view-header">
-                        <BackButton />
                         <h1>Panel de administrador</h1>
                         <p>
                             Bienvenido a la portada de administrador de la Liga Interna de URJC Deportes.

--- a/frontend/src/components/ContentAdminPanel/ContentAdminPanel.test.js
+++ b/frontend/src/components/ContentAdminPanel/ContentAdminPanel.test.js
@@ -8,12 +8,6 @@ jest.mock("react-router-dom", () => ({
     Link: ({ to, children, className }) => <a href={to} className={className}>{children}</a>, // Mock Link for testing purposes
 }));
 
-jest.mock('../../components/backButton/BackButton', () => {
-    const MockBackButton = () => <button>Volver</button>;
-    MockBackButton.displayName = 'MockBackButton';
-    return MockBackButton;
-});
-
 jest.mock('../../context/AuthContext', () => ({
     useAuth: jest.fn()
 }));
@@ -47,12 +41,6 @@ describe("ContentAdminPanel Component", () => {
         render(<ContentAdminPanel />);
         expect(screen.getByRole('heading', { name: /Acceso denegado/i })).toBeInTheDocument();
         expect(screen.queryByRole('heading', { name: /Panel de administrador/i })).not.toBeInTheDocument();
-    });
-
-    it("renders BackButton component for admin users", () => {
-        mockAuthContext.isAdmin.mockReturnValue(true);
-        render(<ContentAdminPanel />);
-        expect(screen.getByRole('button', { name: /Volver/i })).toBeInTheDocument();
     });
 
     it("renders all admin Links with correct 'to' and text for admin users", () => {

--- a/frontend/src/components/fitnessRoomsContent/FitnessRoomsContent.jsx
+++ b/frontend/src/components/fitnessRoomsContent/FitnessRoomsContent.jsx
@@ -8,7 +8,7 @@ const FitnessRoomsContent = () => {
             <h1>Salas de preparación</h1>
             <p>Bienvenido a la página de Salas de preparación de URJC Deportes.
             <br />Aquí podrás darte de alta en las salas de preparación (atletismo y gimnasio) y recargar tu mensualidad.
-            <br />Además, podrás reservar espacio.</p>
+            <br />Además, si quieres reservar espacio, puedes hacerlo <Link to="/instalaciones">aquí</Link>.</p>
             <section>
                 <div className='ligas-internas'>
                     <Link to="/salas-preparacion/alta">

--- a/frontend/src/context/FacilitiesAndReservationsContext.jsx
+++ b/frontend/src/context/FacilitiesAndReservationsContext.jsx
@@ -56,7 +56,6 @@ export const FacilitiesAndReservationsProvider = ({ children }) => {
     };
 
     const addReservation = async (reserva) => {
-        console.log('---addReservation reserva---', reserva);
         try {
             const response = await fetch('http://localhost:4000/reservations', {
                 method: 'POST',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -230,18 +230,7 @@ button.navbar-button {
   margin-bottom: 2rem;
 }
 
-.back-button-div {
-  position: fixed;
-  top: 70px;
-  left: 10px;
-  z-index: 1000;
-}
-
 .back-button {
-  position: relative;
-  top: 20px;
-  left: 10px;
-  padding: 10px 20px;
   background-color: var(--white-color);
   color: var(--primary-color);
   border: none;

--- a/frontend/src/utils/constants/sports.js
+++ b/frontend/src/utils/constants/sports.js
@@ -1,2 +1,18 @@
 export const physicalTrainingSports = ['Gimnasio', 'Atletismo'];
-export const teamSports = ['Fútbol-7', 'Fútbol-sala', 'Básket 3x3', 'Voleibol'];
+export const teamSports = [
+    'Fútbol-7',
+    'Fútbol-sala',
+    'Básket 3x3',
+    'Voleibol'
+];
+export const instalationSports = [
+    'Baloncesto',
+    'Balonmano',
+    'Básket 3x3',
+    'Frontón',
+    'Fútbol-7',
+    'Fútbol-sala',
+    'Pádel',
+    'Tenis',
+    'Voley-playa',
+];

--- a/frontend/src/utils/testUtils.js
+++ b/frontend/src/utils/testUtils.js
@@ -1,0 +1,8 @@
+import { isSubscriptionExpired } from "../utils/user";
+
+export const mockIsSubscriptionExpired = (isGymExpired, isAthleticsExpired) => {
+  isSubscriptionExpired.mockReset?.(); 
+  isSubscriptionExpired
+    .mockImplementationOnce(() => isGymExpired)
+    .mockImplementationOnce(() => isAthleticsExpired);
+};

--- a/frontend/src/views/admin/cover/Users/AdminUsers.jsx
+++ b/frontend/src/views/admin/cover/Users/AdminUsers.jsx
@@ -44,7 +44,6 @@ const AdminUsers = () => {
             return;
         }
         const newPopupData = { ...user };
-        console.log('---newPopupData---', newPopupData);
         setPopupData(newPopupData);
         setIsModalOpen(true);
     };

--- a/frontend/src/views/fitnessRooms/fitnessRoomsReservations/FitnessRoomsReservations.jsx
+++ b/frontend/src/views/fitnessRooms/fitnessRoomsReservations/FitnessRoomsReservations.jsx
@@ -27,8 +27,8 @@ const FitnessRoomsReservations = () => {
     // (también nos sirve para la view de reservas de instalaciones deportivas)
 
     return (
-        <div id="component-content">
-            <div className="back-button-div">
+        <div id="component-content" className="content">
+            <div className="top-buttons-content">
                 <BackButton />
             </div>
             <h1>Reservas de sala de preparación física</h1>

--- a/frontend/src/views/fitnessRooms/paymentSubscription/PaymentSubscription.jsx
+++ b/frontend/src/views/fitnessRooms/paymentSubscription/PaymentSubscription.jsx
@@ -81,7 +81,7 @@ const PaymentSubscription = () => {
 
     return (
         <div id="component-content" className="content">
-            <div className="back-button-div">
+            <div className="top-buttons-content">
                 <BackButton />
             </div>
             <h1>Pago Abono</h1>

--- a/frontend/src/views/fitnessRooms/registration/Registration.jsx
+++ b/frontend/src/views/fitnessRooms/registration/Registration.jsx
@@ -50,7 +50,7 @@ const Registration = () => {
 
     return (
         <div id="component-content" className="content">
-            <div className="back-button-div">
+             <div className="top-buttons-content">
                 <BackButton />
             </div>
             <h1>Alta de sala de preparación física</h1>

--- a/frontend/src/views/instalaciones/Facilities.jsx
+++ b/frontend/src/views/instalaciones/Facilities.jsx
@@ -199,10 +199,6 @@ const Facilities = () => {
         return true;
     };
 
-      console.log('--user--', user);
-      console.log('--completeFacility--', completeFacility);
-      console.log('---selectedInstalacionId---', selectedInstalacionId);
- 
     return (
         <div className="content">
             <h1>Instalaciones</h1>
@@ -220,15 +216,12 @@ const Facilities = () => {
                                 onChange={(e) => {
                                     const value = e.target.value;
                                     setSelectedInstalacionId(value);
-                                    console.log('---value---', value);
 
                                     if (value === '') {
                                         setCompleteFacility({});
                                         return;
                                       }
                                     const selectedFacility = facilities.find(f => f._id === value);
-                                    console.log('selectedFacility', selectedFacility);
-                                    console.log('---checkSubscriptionForFacility(selectedFacility?.name)---', checkSubscriptionForFacility(selectedFacility?.name));
                                     if (!checkSubscriptionForFacility(selectedFacility?.name)) {
                                         // Reset the selected installation if the user doesn't have a subscription
                                         setSelectedInstalacionId('');

--- a/frontend/src/views/instalaciones/Facilities.jsx
+++ b/frontend/src/views/instalaciones/Facilities.jsx
@@ -186,6 +186,23 @@ const Facilities = () => {
         );
     };
 
+    const checkSubscriptionForFacility = (facilityName) => {
+        if (facilityName === 'Gimnasio' && !user?.subscription?.gym?.isActive) {
+          toast.warning('No tienes una suscripción activa en Gimnasio.');
+          return false;
+        }
+      
+        if (facilityName === 'Atletismo' && !user?.subscription?.athletics?.isActive) {
+          toast.warning('No tienes una suscripción activa en Atletismo.');
+          return false;
+        }
+        return true;
+    };
+
+      console.log('--user--', user);
+      console.log('--completeFacility--', completeFacility);
+      console.log('---selectedInstalacionId---', selectedInstalacionId);
+ 
     return (
         <div className="content">
             <h1>Instalaciones</h1>
@@ -193,7 +210,6 @@ const Facilities = () => {
                 <br />Recuerde que el pago de las instalaciones se debe efectuar en efectivo al llegar.
                 <br />Las reservas son de media hora en media hora.
             </p>
-
             {user ?
                 <form onSubmit={handleSubmit(onSubmit)} className="form-reservar" data-testid="reservation-form">
                     <div>
@@ -202,13 +218,30 @@ const Facilities = () => {
                                 {...register("facilityId", { required: "Por favor, selecciona un deporte" })}
                                 value={selectedInstalacionId}
                                 onChange={(e) => {
-                                    setSelectedInstalacionId(e.target.value);
+                                    const value = e.target.value;
+                                    setSelectedInstalacionId(value);
+                                    console.log('---value---', value);
+
+                                    if (value === '') {
+                                        setCompleteFacility({});
+                                        return;
+                                      }
+                                    const selectedFacility = facilities.find(f => f._id === value);
+                                    console.log('selectedFacility', selectedFacility);
+                                    console.log('---checkSubscriptionForFacility(selectedFacility?.name)---', checkSubscriptionForFacility(selectedFacility?.name));
+                                    if (!checkSubscriptionForFacility(selectedFacility?.name)) {
+                                        // Reset the selected installation if the user doesn't have a subscription
+                                        setSelectedInstalacionId('');
+                                        return;
+                                    }
+
                                     getMinTime(); // update minTime
                                     getMaxTime(); // update maxTime
                                     getCompleteFacility(e.target.value);
                                 }
                                 }
                             >
+                                <option value="">Escoge una instalación</option>
                                 {facilities.map(facility => (
                                     <option key={facility?._id} value={facility?._id}>
                                         {facility.name}
@@ -218,10 +251,19 @@ const Facilities = () => {
                         </label>
                     </div>
                     <div>
-                        <>Horario de inicio: {completeFacility.schedule && completeFacility.schedule.initialHour ? getHoursAndMinutes(completeFacility.schedule.initialHour) : 'No definido'}<br />
-                            Horario de fin: {completeFacility.schedule && completeFacility.schedule.endHour ? getHoursAndMinutes(completeFacility.schedule.endHour) : 'No definido'}</>
+                        {completeFacility && completeFacility.schedule ? (
+                            <>
+                                Horario de inicio: {completeFacility.schedule.initialHour ? getHoursAndMinutes(completeFacility.schedule.initialHour) : 'No definido'}<br />
+                                Horario de fin: {completeFacility.schedule.endHour ? getHoursAndMinutes(completeFacility.schedule.endHour) : 'No definido'}
+                            </>
+                        ) : (
+                        <p>Selecciona una instalación para ver el horario.</p>
+                        )}
+
                         {selectedInstalacionId && (<p>Precio por media hora: {completeFacility?.priceForHalfHour}€.</p>)}
-                        {completeFacility && <p>Capacidad por reserva para {completeFacility.name}: {completeFacility.capacity}</p>}
+                        {selectedInstalacionId && completeFacility?.capacity !== undefined && (
+                            <p>Capacidad por reserva para {completeFacility.name}: {completeFacility.capacity}</p>
+                        )}
                     </div>
 
                     {selectedInstalacionId ? (

--- a/frontend/src/views/instalaciones/Facilities.test.js
+++ b/frontend/src/views/instalaciones/Facilities.test.js
@@ -8,6 +8,7 @@ import Facilities from "./Facilities";
 import { useAuth } from "../../context/AuthContext";
 import { useFacilitiesAndReservations } from "../../context/FacilitiesAndReservationsContext";
 import { mockAuthContext, mockFacilitiesAndReservationsContext } from "../../utils/mocks";
+import { toast } from 'sonner';
 
 jest.mock('../../context/AuthContext', () => ({
     useAuth: jest.fn()
@@ -19,6 +20,15 @@ jest.mock('../../context/FacilitiesAndReservationsContext', () => ({
 
 jest.mock('../../utils/mails', () => ({
     sendEmail: jest.fn()
+}));
+
+jest.mock('sonner', () => ({
+    toast: {
+        warning: jest.fn(),
+        error: jest.fn(),
+        success: jest.fn(),
+        promise: jest.fn((fn) => fn()),
+    },
 }));
 
 describe("Facilities Component", () => {
@@ -88,7 +98,7 @@ describe("Facilities Component", () => {
             it("displays price per media hora when a facility is selected", async () => {
                 mockFacilitiesAndReservationsContext.getAllFacilities.mockResolvedValue([{ _id: '1', name: 'Pista 1', priceForHalfHour: 20 }]);
                 mockFacilitiesAndReservationsContext.getFacility.mockResolvedValue({ _id: '1', name: 'Pista 1', priceForHalfHour: 20, capacity: 5 });
-    
+
                 render(<Facilities />);
                 await waitFor(() => {
                     fireEvent.change(screen.getByRole('combobox', { name: /instalación/i }), { target: { value: '1' } });
@@ -97,29 +107,43 @@ describe("Facilities Component", () => {
             });
 
             it("displays capacity per reserva when a facility is selected", async () => {
-                mockFacilitiesAndReservationsContext.getAllFacilities.mockResolvedValue([{ _id: '1', name: 'Pista 1', capacity: 5 }]);
-                mockFacilitiesAndReservationsContext.getFacility.mockResolvedValue({ _id: '1', name: 'Pista 1', priceForHalfHour: 20, capacity: 5 });
+                const facility = {
+                  _id: '1',
+                  name: 'Pista 1',
+                  priceForHalfHour: 20,
+                  capacity: 5,
+                  schedule: {
+                    initialHour: new Date(),
+                    endHour: new Date()
+                  }
+                };
+
+                mockFacilitiesAndReservationsContext.getAllFacilities.mockResolvedValue([facility]);
+                mockFacilitiesAndReservationsContext.getFacility.mockResolvedValue(facility);
+
+                render(<Facilities />);
+
+                const select = await screen.findByRole('combobox', { name: /instalación/i });
+                fireEvent.change(select, { target: { value: '1' } });
+              
+                await waitFor(() => {
+                  expect(screen.getByText(/Precio por media hora: 20€/i)).toBeInTheDocument();
+                  expect(screen.getByText(/Capacidad por reserva para Pista 1: 5/i)).toBeInTheDocument();
+                });
+              });
+              
+
+            it("renders DatePicker and Reservar button when facility is selected", async () => {
+                mockFacilitiesAndReservationsContext.getAllFacilities.mockResolvedValue([{ _id: '1', name: 'Pista 1', priceForHalfHour: 20 }]);
+                mockFacilitiesAndReservationsContext.getFacility.mockResolvedValue({ _id: '1', name: 'Pista 1', schedule: { initialHour: new Date('2023-08-03T09:00'), endHour: new Date('2023-08-03T19:00') }, priceForHalfHour: 20, capacity: 5 });
 
                 render(<Facilities />);
                 await waitFor(() => {
                     fireEvent.change(screen.getByRole('combobox', { name: /instalación/i }), { target: { value: '1' } });
-                });
-                await waitFor(() => {
-                    expect(screen.getByText(/Capacidad por reserva para Pista 1: 5/i)).toBeInTheDocument();
+                    expect(screen.getByRole('textbox')).toBeInTheDocument(); // DatePicker
+                    expect(screen.getByRole('button', { name: /Reservar/i })).toBeInTheDocument();
                 });
             });
-
-            it("renders DatePicker and Reservar button when facility is selected", async () => {
-                mockFacilitiesAndReservationsContext.getAllFacilities.mockResolvedValue([{ _id: '1', name: 'Pista 1', priceForHalfHour: 20 }]);
-                mockFacilitiesAndReservationsContext.getFacility.mockResolvedValue({ _id: '1', name: 'Pista 1', schedule: { initialHour: new Date('2023-08-03T09:00'), endHour: new Date('2023-08-03T19:00')}, priceForHalfHour: 20, capacity: 5 });
-   
-               render(<Facilities />);
-               await waitFor(() => {
-                   fireEvent.change(screen.getByRole('combobox', { name: /instalación/i }), { target: { value: '1' } });
-                   expect(screen.getByRole('textbox')).toBeInTheDocument(); // DatePicker
-                   expect(screen.getByRole('button', { name: /Reservar/i })).toBeInTheDocument();
-               });
-           });
         });
 
         // TODO: completar tests desde aquí
@@ -139,19 +163,19 @@ describe("Facilities Component", () => {
             it("calls obtenerInstalacionCompleta  when facility is selected", async () => {
                 mockFacilitiesAndReservationsContext.getAllFacilities.mockResolvedValue([{ _id: '1', name: 'Pista 1' }]);
                 render(<Facilities />);
-    
+
                 await waitFor(async () => {
                     fireEvent.change(screen.getByRole('combobox', { name: /instalación/i }), { target: { value: '1' } });
                     await new Promise(resolve => setTimeout(resolve, 0));
                     expect(mockFacilitiesAndReservationsContext.getFacility).toHaveBeenCalled();
                 });
             });
-    
+
             it("updates startDate state on date change in DatePicker", async () => {
                 mockFacilitiesAndReservationsContext.getAllFacilities.mockResolvedValue([{ _id: '1', name: 'Pista 1', priceForHalfHour: 20 }]);
-                mockFacilitiesAndReservationsContext.getFacility.mockResolvedValue({ _id: '1', name: 'Pista 1', schedule: { initialHour: new Date('2023-08-03T09:00'), endHour: new Date('2023-08-03T19:00')}, priceForHalfHour: 20, capacity: 5 });
+                mockFacilitiesAndReservationsContext.getFacility.mockResolvedValue({ _id: '1', name: 'Pista 1', schedule: { initialHour: new Date('2023-08-03T09:00'), endHour: new Date('2023-08-03T19:00') }, priceForHalfHour: 20, capacity: 5 });
                 render(<Facilities />);
-    
+
                 await waitFor(() => {
                     fireEvent.change(screen.getByRole('combobox', { name: /instalación/i }), { target: { value: '1' } });
                     const datePicker = screen.getByRole('textbox');
@@ -183,36 +207,156 @@ describe("Facilities Component", () => {
                 mockFacilitiesAndReservationsContext.addReservation.mockResolvedValue({ ok: true, data: { totalPrice: 20 } });
                 mockFacilitiesAndReservationsContext.getMinTime.mockResolvedValue(new Date(new Date().setHours(9, 0, 0)));
                 mockFacilitiesAndReservationsContext.getMaxTime.mockResolvedValue(new Date(new Date().setHours(19, 30, 0)));
-            
+
                 render(<Facilities />);
 
                 await waitFor(() => {
                     fireEvent.change(screen.getByRole('combobox', { name: /instalación/i }), { target: { value: '1' } });
                     expect(screen.getByText(/Precio por media hora: 20€./i)).toBeInTheDocument();
                 });
-            
+
                 await waitFor(() => {
                     expect(screen.getByText(/Capacidad por reserva para Fútbol sala:/i)).toBeInTheDocument();
                 });
-            
+
                 await waitFor(() => {
                     expect(screen.getByRole("textbox")).toBeInTheDocument();
                 });
-            
+
                 const datePicker = screen.getByRole("textbox");
                 fireEvent.change(datePicker, { target: { value: "2024-08-05T10:00" } });
-            
+
                 await waitFor(() => {
                     const submitButton = screen.getByRole("button", { name: /Reservar/i });
                     expect(submitButton).not.toBeDisabled();
                     fireEvent.click(submitButton);
                 });
-            
+
                 // await waitFor(() => {
                 //     expect(mockFacilitiesAndReservationsContext.addReservation).toHaveBeenCalledTimes(1);
                 // });
             });
-            
+
+        });
+    });
+
+    describe("Gym and Athletics Subscription", () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+        it("shows warning and prevents selection if user lacks active Gym subscription", async () => {
+            toast.warning.mockClear();
+          
+            mockAuthContext.user = {
+              _id: '1',
+              email: 'test@test.com',
+              name: 'Test User',
+              subscription: { gym: { isActive: false } }
+            };
+          
+            const facilitiesMock = [{ _id: '1', name: 'Gimnasio' }];
+            mockFacilitiesAndReservationsContext.getAllFacilities.mockResolvedValue(facilitiesMock);
+          
+            render(<Facilities />);
+          
+            await waitFor(() => {
+              expect(screen.getByRole('option', { name: 'Gimnasio' })).toBeInTheDocument();
+            });
+          
+            fireEvent.change(screen.getByRole('combobox', { name: /instalación/i }), {
+              target: { value: '1' }
+            });
+          
+            await waitFor(() => {
+              expect(toast.warning).toHaveBeenCalledWith('No tienes una suscripción activa en Gimnasio.');
+            });
+            await waitFor(() => {
+                const select = screen.getByRole('combobox', { name: /instalación/i });
+                expect(select.value).toBe('');
+            });
+        });
+
+        it("shows warning and prevents selection if user lacks active Athletics subscription", async () => {
+            toast.warning.mockClear();
+          
+            mockAuthContext.user = {
+              _id: '1',
+              email: 'test@test.com',
+              name: 'Test User',
+              subscription: { athletics: { isActive: false } }
+            };
+          
+            const facilitiesMock = [{ _id: '2', name: 'Atletismo' }];
+            mockFacilitiesAndReservationsContext.getAllFacilities.mockResolvedValue(facilitiesMock);
+          
+            render(<Facilities />);
+          
+            await waitFor(() => {
+              expect(screen.getByRole('option', { name: 'Atletismo' })).toBeInTheDocument();
+            });
+          
+            fireEvent.change(screen.getByRole('combobox', { name: /instalación/i }), {
+              target: { value: '2' }
+            });
+          
+            await waitFor(() => {
+              expect(toast.warning).toHaveBeenCalledWith('No tienes una suscripción activa en Atletismo.');
+            });
+            await waitFor(() => {
+                const select = screen.getByRole('combobox', { name: /instalación/i });
+                expect(select.value).toBe('');
+            });
+        });
+
+        it("allows selection if user has active subscriptions for Gym and Athletics", async () => {
+            mockAuthContext.user = {
+              _id: '1',
+              email: 'test@test.com',
+              name: 'Test User',
+              registration: {
+                gym: { isActive: true },
+                athletics: { isActive: true }
+              },
+              subscription: {
+                gym: { isActive: true },
+                athletics: { isActive: true }
+              }
+            };
+          
+            const facilitiesMock = [
+              { _id: '1', name: 'Gimnasio' },
+              { _id: '2', name: 'Atletismo' }
+            ];
+          
+            mockFacilitiesAndReservationsContext.getAllFacilities.mockResolvedValue(facilitiesMock);
+            mockFacilitiesAndReservationsContext.getFacility.mockResolvedValue({
+              _id: '1',
+              name: 'Gimnasio',
+              schedule: {
+                initialHour: new Date(),
+                endHour: new Date()
+              },
+              capacity: 5,
+              priceForHalfHour: 10
+            });
+          
+            render(<Facilities />);
+          
+            // Wait for the facilities to be rendered
+            await waitFor(() => {
+              expect(screen.getByRole('option', { name: 'Gimnasio' })).toBeInTheDocument();
+            });
+          
+            fireEvent.change(screen.getByRole('combobox', { name: /instalación/i }), {
+              target: { value: '1' }
+            });
+          
+            // Wait for the facility details to be displayed
+            await waitFor(() => {
+              expect(
+                screen.getByText(/Capacidad por reserva para Gimnasio: 5/i)
+              ).toBeInTheDocument();
+            });
         });
     });
 });

--- a/frontend/src/views/ligas_internas/rankings/Rankings.jsx
+++ b/frontend/src/views/ligas_internas/rankings/Rankings.jsx
@@ -21,15 +21,13 @@ const Rankings = () => {
 
     return (
         <div id="component-content" className="content">
-            <div className="back-button-div">
+            <div className="top-buttons-content">
                 <BackButton />
             </div>
-            
             <div className="view-header">
                 <h1>Clasificaciones Ligas Internas</h1>
                 <p>Consulta las clasificaciones de las ligas internas de la URJC</p>
             </div>
-
             <select value={selectedSport} onChange={handleDeporteChange}>
                 <option value="Todos">Todos</option>
                 <option value="Fútbol-7">Fútbol-7</option>

--- a/frontend/src/views/ligas_internas/results/Results.css
+++ b/frontend/src/views/ligas_internas/results/Results.css
@@ -78,9 +78,9 @@ th, td {
 @media (max-width: 768px) {
     /* Estilos para pantallas pequeñas */
     .top-buttons-content {
-        flex-direction: column;
+        /* flex-direction: column;
         align-items: flex-start;
-        padding: 10px;
+        padding: 10px; */
     }
 
     .iconPlus {

--- a/frontend/src/views/ligas_internas/results/Results.jsx
+++ b/frontend/src/views/ligas_internas/results/Results.jsx
@@ -16,7 +16,7 @@ import { getPrettyDate } from "../../../utils/dates";
 const Results = () => {
     const { user, isAdmin } = useAuth();
     const { results, fetchResults, deleteResult } = useTeamsAndResults();
-    const [selectedSport, setSelectedSport] = useState('Fútbol-7');
+    const [selectedSport, setSelectedSport] = useState('');
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [popupData, setPopupData] = useState(null);
     const [isNewResult, setIsNewResult] = useState(false);
@@ -32,20 +32,21 @@ const Results = () => {
         setSelectedSport(event.target.value);
     };
 
-    const filteredResults = results?.filter((results) => {
-        return selectedSport === 'Fútbol-7' || results.sport === selectedSport;
-    });
+    const filteredResults = results?.filter(result => selectedSport && result.sport === selectedSport);
+    // Sort the results by round
+    const sortedResults = filteredResults?.sort((a, b) => a.round - b.round);
 
     const openModal = async (result) => {
         if (!result) {
             setPopupData({
                 sport: '',
-                round: '',
+                round: 1,
+                localTeam: '',
                 localTeamId: '',
-                localGoals: '',
-                visitorTeam: 0,
-                visitorTeamId: 0,
-                visitorGoals: '',
+                localGoals: 0,
+                visitorTeam: '',
+                visitorTeamId: '',
+                visitorGoals: 0,
                 date: '',
                 hour: '',
                 place: ''
@@ -101,14 +102,18 @@ const Results = () => {
             )}
             <section className="table-responsive">
                 <select value={selectedSport} onChange={handleDeporteChange}>
+                    <option value="">Elige un deporte</option>
                     <option value="Fútbol-7">Fútbol-7</option>
                     <option value="Fútbol-sala">Fútbol-sala</option>
                     <option value="Básket 3x3">Básket 3x3</option>
                     <option value="Voleibol">Voleibol</option>
                 </select>
 
-                {filteredResults?.length === 0 ?
-                    <p>No hay resultados de {selectedSport} para mostrar</p> :
+                {!selectedSport ? (
+                    <p>Selecciona un deporte para ver sus resultados</p>
+                ) : sortedResults?.length === 0 ? (
+                    <p>No hay resultados de {selectedSport} para mostrar</p>
+                ) : (
                     <table>
                         <thead>
                             <tr>
@@ -123,7 +128,7 @@ const Results = () => {
                             </tr>
                         </thead>
                         <tbody>
-                            {filteredResults?.map((results) => (
+                            {sortedResults?.map((results) => (
                                 <tr key={results._id}>
                                     <td>{results.round}</td>
                                     <td>{results.localTeam}</td>
@@ -144,7 +149,7 @@ const Results = () => {
                             ))}
                         </tbody>
                     </table>
-                }
+                )}
             </section>
         </div>
     );

--- a/frontend/src/views/profile/myReservations/MyReservations.jsx
+++ b/frontend/src/views/profile/myReservations/MyReservations.jsx
@@ -5,6 +5,7 @@ import { MdAttachMoney, MdMoneyOff } from "react-icons/md";
 import { useAuth } from '../../../context/AuthContext';
 import { useFacilitiesAndReservations } from '../../../context/FacilitiesAndReservationsContext';
 import { getPrettyDate } from '../../../utils/dates';
+import BackButton from '../../../components/backButton/BackButton';
 
 const MyReservations = () => {
     const { user } = useAuth();
@@ -38,7 +39,10 @@ const MyReservations = () => {
     };
 
     return (
-        <div>
+        <div id="component-content" className="content">
+            <div className="top-buttons-content">
+                <BackButton />
+            </div>
             <h1>Mis Reservas</h1>
             <div className='content-mis-reservas'>
                 {user ? ( 

--- a/frontend/src/views/profile/mySubscriptions/MySubscriptions.jsx
+++ b/frontend/src/views/profile/mySubscriptions/MySubscriptions.jsx
@@ -33,15 +33,14 @@ const MySubscriptions = () => {
     const athleticsRegistrationDateInit = getPrettyDate(user?.registration?.athletics?.initDate);
 
     // Subscriptions
-    const subscriptionStateAtletismo = user?.subscription?.athletics?.isActive;
-    const subscriptionStateGimnasio = user?.subscription?.gym?.isActive;
+    const subscriptionIsActiveGimnasio = user?.subscription?.gym?.isActive;
+    const subscriptionIsActiveAtletismo = user?.subscription?.athletics?.isActive;
     const gymSubsDateInit = getPrettyDate(user?.subscription?.gym?.initDate);
     const gymSubsDateEnd = getPrettyDate(user?.subscription?.gym?.endDate);
     const athleticsSubsDateInit = getPrettyDate(user?.subscription?.athletics?.initDate);
     const athleticsSubsDateEnd = getPrettyDate(user?.subscription?.athletics?.endDate);
     const isGymExpired = isSubscriptionExpired(user?.subscription?.gym);
     const isAthleticsExpired = isSubscriptionExpired(user?.subscription?.athletics);
-
 
     return (
         <div>
@@ -53,15 +52,11 @@ const MySubscriptions = () => {
                             <p>Usuario: {user?.name}</p>
                             <p>Fecha alta: { registrationGym ? gymRegistrationDateInit : 'No estás dado de alta'}</p>
                             <h2>GIMNASIO MENSUAL</h2>
-                            { subscriptionStateGimnasio ? (
-                                isGymExpired ? (
-                                    <p>Abono caducado</p>
-                                ) : (
+                            { subscriptionIsActiveGimnasio ? (
                                     <Fragment>
                                         <p>Abono activo</p>
                                         <p>Fecha alta: { gymSubsDateInit }</p>
                                         <p>Fecha caducidad: { gymSubsDateEnd }</p>
-                                        {/* <p>{ user?.registration?.gym?.initDate?.toLocaleDateString('es-ES', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}</p> */}
                                         <button
                                             onClick={()=> {
                                                 toast.promise(handleUnsubscribe('gym'), {
@@ -74,24 +69,24 @@ const MySubscriptions = () => {
                                                 })
                                             }}>Darme de baja</button>
                                     </Fragment>
+                                ) : (
+                                    isGymExpired ? (
+                                        <p>Abono caducado</p>
+                                    ) : (
+                                    <p>Abono inactivo</p>
+                                    )
                                 )
-                            ) : (
-                                <p>Abono inactivo</p>
-                            )}
+                            }
                         </div>
                         <div className="card-no-hover">
                             <p>Usuario: {user?.name}</p>
                             <p>Fecha de alta: { registrationAthletics ? athleticsRegistrationDateInit : 'No estás dado de alta' }</p>
                             <h2>ATLETISMO MENSUAL</h2>
-                            { subscriptionStateAtletismo ? (
-                                isAthleticsExpired ? (
-                                    <p>Abono caducado</p>
-                                ) : (
+                            { subscriptionIsActiveAtletismo  ? (
                                     <Fragment>
                                         <p>Abono activo</p>
                                         <p>Fecha inicio: { athleticsSubsDateInit }</p>
                                         <p>Fecha caducidad: { athleticsSubsDateEnd }</p>
-                                        {/* <p>{ user?.registration?.athletics?.initDate?.toLocaleDateString('es-ES', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}</p> */}
                                         <button
                                             onClick={()=> {
                                                 toast.promise(handleUnsubscribe('athletics'), {
@@ -104,10 +99,14 @@ const MySubscriptions = () => {
                                                 })
                                             }}>Darme de baja</button>
                                     </Fragment>
+                                ) : (
+                                    isAthleticsExpired ? (
+                                        <p>Abono caducado</p>
+                                    ) : (
+                                        <p>Abono inactivo</p>
+                                    )
                                 )
-                            ) : (
-                                <p>Abono inactivo</p>
-                            )}
+                            }
                         </div>
                     </div>
                 ): <p>Debes iniciar sesión para acceder a tus abonos</p>}

--- a/frontend/src/views/profile/seeProfile/SeeProfile.jsx
+++ b/frontend/src/views/profile/seeProfile/SeeProfile.jsx
@@ -4,6 +4,7 @@ import './SeeProfile.css';
 import { useAuth } from "../../../context/AuthContext";
 import { useNavigate } from 'react-router-dom';
 import { useFacilitiesAndReservations } from "../../../context/FacilitiesAndReservationsContext";
+import BackButton from "../../../components/backButton/BackButton";
 
 const SeeProfile = () => {
     const { user, updateUserAndCookie, isAdmin, logout, deleteUser, updatePasswordAndName } = useAuth();
@@ -72,6 +73,9 @@ const SeeProfile = () => {
 
     return (
         <Fragment>
+            <div className="top-buttons-content">
+                <BackButton />
+            </div>
             <div className="profile-content">
                 <div id="profile-card">
                     <div className="card-no-hover">


### PR DESCRIPTION
### SUMMARY
Trello ticket: https://trello.com/c/7b7WunkN/124-dpurjc-043-mejoras-en-visualizaci%C3%B3n-de-resultados-navegaci%C3%B3n-y-restricciones-de-reserva

> **Resultados ordenados por jornada**
> - Se deberían mostrar los resultados ordenados por número de jornada (round) para mayor claridad.
> 
> **Corrección en Fútbol 7**
> - Se debe solucionar un bug en el componente Results que muestra resultados de todos los deportes al seleccionar "Fútbol 7".
> 
> **Refactor de botones "Volver"**
> - Se eliminan o ajustan los botones de "Volver" en páginas donde no tienen sentido (como landings principales).
> - Solo se muestran en páginas hijas como /admin-panel/admin-equipos.
> 
> **Restricción de reservas por suscripción**
> - En /instalaciones, se debe bloquear el acceso a reservar Gimnasio o Atletismo si el usuario no tiene una suscripción activa.
> - Se debe mostrar un toast.warning cuando se intente reservar sin cumplir los requisitos.
> 

### Expected behaviour

Resultados ordenados por jornada y por defecto no debería aparecer ninguno (al abrir la landing).
Botones de volver deben aparecer en landings que sean hijas de otras.


### Before Screenshots
![image](https://github.com/user-attachments/assets/1f12beae-db17-440e-a5a9-2c0d956ff8ae)
![image](https://github.com/user-attachments/assets/26656d47-0166-4476-9adc-c4997cd5facb)


### After Screenshots
![image](https://github.com/user-attachments/assets/34f85053-cabe-43a1-8b1e-9c95502a0137)
![image](https://github.com/user-attachments/assets/6a9244ff-c2c5-443d-9ad1-afeb92ee37e1)

![image](https://github.com/user-attachments/assets/7427edca-d20f-42f7-9c94-eccbb46d5261)

