### PR TITLE
[DPURJC-047] - paginación en reservas

### DIFF
--- a/frontend/src/views/admin/cover/Reservation/AdminReservations.css
+++ b/frontend/src/views/admin/cover/Reservation/AdminReservations.css
@@ -1,0 +1,7 @@
+
+  
+  .pagination button.active {
+    color: var(--primary-color);;
+    font-weight: bold;
+  }
+  

--- a/frontend/src/views/admin/cover/Reservation/AdminReservations.jsx
+++ b/frontend/src/views/admin/cover/Reservation/AdminReservations.jsx
@@ -23,6 +23,17 @@ const AdminReservations = () => {
   const [popupData, setPopupData] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
 
+  // Paginación
+  const [currentPage, setCurrentPage] = useState(1);
+  const reservationsPerPage = 10;
+  const totalPages = Math.ceil(reservations.length / reservationsPerPage);
+  const maxPageButtons = 5;
+
+  const paginatedReservations = reservations.slice(
+    (currentPage - 1) * reservationsPerPage,
+    currentPage * reservationsPerPage
+  );
+
   const fetchReservations = async () => {
     try {
       setIsLoading(true);
@@ -39,14 +50,14 @@ const AdminReservations = () => {
   }, []);
 
   const openModal = (reservation) => {
-    setPopupData(reservation || null); // Edition mode if passed a reservation
+    setPopupData(reservation || null);
     setIsModalOpen(true);
   };
 
   const closeModal = () => {
     setIsModalOpen(false);
     setPopupData(null);
-    fetchReservations(); // Refresh reservations list
+    fetchReservations();
   };
 
   const handleDeleteReservation = async (reservationId) => {
@@ -60,80 +71,106 @@ const AdminReservations = () => {
       fetchReservations();
     } catch (error) {
       toast.error("Error al eliminar reserva.");
-      console.error("Error al eliminar reserva:", error);
     }
   };
 
-  if (!isAdmin()) {
-    return <AccessDenied />;
-  }
+  const getVisiblePages = () => {
+    const pages = [];
+    let startPage = Math.max(1, currentPage - Math.floor(maxPageButtons / 2));
+    let endPage = startPage + maxPageButtons - 1;
+
+    if (endPage > totalPages) {
+      endPage = totalPages;
+      startPage = Math.max(1, endPage - maxPageButtons + 1);
+    }
+
+    for (let i = startPage; i <= endPage; i++) {
+      pages.push(i);
+    }
+    return pages;
+  };
+
+  if (!isAdmin()) return <AccessDenied />;
 
   return (
     <div id="component-content">
-        {isLoading && <Spinner />}
-        <Fragment>
-            {isModalOpen && (
-                <AdminModalReservations
-                closeModal={closeModal}
-                isOpen={isModalOpen}
-                popupData={popupData}
-                />
-            )}
-            <div className="top-buttons-content">
-                <BackButton />
-                <GoPlus onClick={() => openModal()} className="iconPlus" size="1.5em" />
+      {isLoading && <Spinner />}
+      <>
+        {isModalOpen && (
+          <AdminModalReservations
+            closeModal={closeModal}
+            isOpen={isModalOpen}
+            popupData={popupData}
+          />
+        )}
+        <div className="top-buttons-content">
+          <BackButton />
+          <GoPlus onClick={() => openModal()} className="iconPlus" size="1.5em" />
+        </div>
+        <h1>Reservas</h1>
+        <p>Aquí puedes administrar las reservas realizadas en la web.</p>
+
+        <section>
+          <table>
+            <thead>
+              <tr>
+                <th>Usuario</th>
+                <th>Instalación</th>
+                <th>Fecha inicio</th>
+                <th>Fecha fin</th>
+                <th>Precio total</th>
+                <th>Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {paginatedReservations.map((reservation) => (
+                <tr key={reservation._id}>
+                  <td>{reservation.userId}</td>
+                  <td>{reservation.facilityId}</td>
+                  <td>{getPrettyDate(reservation.initDate)}</td>
+                  <td>{getPrettyDate(reservation.endDate)}</td>
+                  <td>
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                      {reservation.totalPrice} €
+                      {reservation.isPaid ? (
+                        <MdAttachMoney title="Pagado" style={{ marginLeft: '0.5rem', color: 'green' }} />
+                      ) : (
+                        <MdMoneyOff title="Pendiente de pago" style={{ marginLeft: '0.5rem', color: 'red' }} />
+                      )}
+                    </div>
+                  </td>
+                  <td>
+                    <GoPencil onClick={() => openModal(reservation)} className="editPencil" />
+                    <MdOutlineDelete onClick={() => handleDeleteReservation(reservation._id)} className="deleteTrash" />
+                    <IoPersonOutline onClick={() => navigate(`/admin-panel/admin-usuarios/${reservation.userId}`)} className="infoButton" />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {/* Paginación */}
+          {totalPages > 1 && (
+            <div className="pagination">
+              <button onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))} disabled={currentPage === 1}>
+                Anterior
+              </button>
+              {getVisiblePages().map((page) => (
+                <button
+                  key={page}
+                  onClick={() => setCurrentPage(page)}
+                  className={page === currentPage ? 'active' : ''}
+                >
+                  {page}
+                </button>
+              ))}
+              <button onClick={() => setCurrentPage((prev) => Math.min(prev + 1, totalPages))} disabled={currentPage === totalPages}>
+                Siguiente
+              </button>
             </div>
-            <h1>Reservas</h1>
-            <p>Aquí puedes administrar las reservas realizadas en la web.</p>
-            <section>
-                <table>
-                <thead>
-                    <tr>
-                    <th>Usuario</th>
-                    <th>Instalación</th>
-                    <th>Fecha inicio</th>
-                    <th>Fecha fin</th>
-                    <th>Precio total</th>
-                    <th>Acciones</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {reservations.map((reservation) => (
-                        <tr key={reservation?._id}>
-                            <td>{reservation?.userId}</td>
-                            <td>{reservation?.facilityId}</td>
-                            <td>{getPrettyDate(reservation?.initDate)}</td>
-                            <td>{getPrettyDate(reservation?.endDate)}</td>
-                            <td>
-                              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                                  {reservation?.totalPrice} €
-                                  {reservation?.isPaid ? (
-                                      <MdAttachMoney title="Pagado" style={{ marginLeft: '0.5rem', color: 'green', width: '1.5em', height: '1.5em' }} />
-                                  ) : (
-                                      <MdMoneyOff title="Pendiente de pago" style={{ marginLeft: '0.5rem', color: 'red', width: '1.5em', height: '1.5em' }} />
-                                  )}
-                              </div>
-                            </td>
-                            <td>
-                            <GoPencil
-                                onClick={() => openModal(reservation)}
-                                className="editPencil"
-                            />
-                            <MdOutlineDelete
-                                onClick={() => handleDeleteReservation(reservation?._id)}
-                                className="deleteTrash"
-                            />
-                            <IoPersonOutline 
-                                onClick={() => navigate(`/admin-panel/admin-usuarios/${reservation?.userId}`)}
-                                className="infoButton"
-                            />
-                            </td>
-                        </tr>
-                    ))}
-                </tbody>
-                </table>
-            </section>
-        </Fragment>
+          )}
+        </section>
+      </>
     </div>
   );
 };

--- a/frontend/src/views/profile/myReservations/MyReservations.css
+++ b/frontend/src/views/profile/myReservations/MyReservations.css
@@ -1,8 +1,26 @@
 .content-mis-reservas {
     display: flex;
     place-content: center;
+    flex-direction: column;
 }
 .table-mis-reservas > tbody > tr > * {
     padding: 1rem;;
 }
 
+.pagination {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 1rem;
+  }
+  
+  .pagination button {
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+  }
+  
+  .pagination button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  

--- a/frontend/src/views/profile/myReservations/MyReservations.css
+++ b/frontend/src/views/profile/myReservations/MyReservations.css
@@ -10,6 +10,7 @@
 .pagination {
     display: flex;
     justify-content: center;
+    align-items: center;
     gap: 1rem;
     margin-top: 1rem;
   }

--- a/frontend/src/views/profile/myReservations/MyReservations.jsx
+++ b/frontend/src/views/profile/myReservations/MyReservations.jsx
@@ -12,6 +12,10 @@ const MyReservations = () => {
     const { facilities, deleteReservation, getAllReservations } = useFacilitiesAndReservations();
     const [filteredReservations, setFilteredReservations] = useState([]);
 
+    // 🔸 Paginación
+    const [currentPage, setCurrentPage] = useState(1);
+    const itemsPerPage = 5;
+
     const fetchReservas = async () => {
         const reservations = await getAllReservations();
         if (user) {
@@ -38,6 +42,12 @@ const MyReservations = () => {
         }
     };
 
+    // 🔸 Cálculo de páginas
+    const indexOfLast = currentPage * itemsPerPage;
+    const indexOfFirst = indexOfLast - itemsPerPage;
+    const currentReservations = filteredReservations.slice(indexOfFirst, indexOfLast);
+    const totalPages = Math.ceil(filteredReservations.length / itemsPerPage);
+
     return (
         <div id="component-content" className="content">
             <div className="top-buttons-content">
@@ -45,9 +55,9 @@ const MyReservations = () => {
             </div>
             <h1>Mis Reservas</h1>
             <div className='content-mis-reservas'>
-                {user ? ( 
-                    filteredReservations.length <= 0  ? ( 
-                        <p>No tienes reservas.</p> 
+                {user ? (
+                    filteredReservations.length <= 0 ? (
+                        <p>No tienes reservas.</p>
                     ) : (
                         <>
                             <table className="table-mis-reservas">
@@ -61,7 +71,7 @@ const MyReservations = () => {
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {filteredReservations.map((reserva) => (
+                                    {currentReservations.map((reserva) => (
                                         <tr key={reserva._id}>
                                             <td>{facilities.find(facility => facility._id === reserva.facilityId)?.name}</td>
                                             <td>{getPrettyDate(reserva.initDate)}</td>
@@ -85,9 +95,28 @@ const MyReservations = () => {
                                     ))}
                                 </tbody>
                             </table>
+
+                            {/* 🔸 Controles de paginación */}
+                            <div className="pagination">
+                                <button
+                                    onClick={() => setCurrentPage(prev => Math.max(prev - 1, 1))}
+                                    disabled={currentPage === 1}
+                                >
+                                    Anterior
+                                </button>
+                                <span>Página {currentPage} de {totalPages}</span>
+                                <button
+                                    onClick={() => setCurrentPage(prev => Math.min(prev + 1, totalPages))}
+                                    disabled={currentPage === totalPages}
+                                >
+                                    Siguiente
+                                </button>
+                            </div>
                         </>
-                    ))
-                : <p>Inicia sesión para acceder a tus reservas</p>}
+                    )
+                ) : (
+                    <p>Inicia sesión para acceder a tus reservas</p>
+                )}
             </div>
         </div>
     );

--- a/frontend/src/views/profile/myReservations/MyReservations.test.js
+++ b/frontend/src/views/profile/myReservations/MyReservations.test.js
@@ -34,7 +34,8 @@ describe("MyReservations Component", () => {
         mockAuthContext.user = { _id: '123', name: 'Test User' };
         mockFacilitiesAndReservationsContext.facilities = [{ _id: '1', name: 'Gimnasio' }, { _id: '2', name: 'Pista Atletismo' }];
         mockFacilitiesAndReservationsContext.getAllReservations.mockResolvedValue([
-            { _id: 'res1',
+            {
+                _id: 'res1',
                 userId: '123',
                 facilityId: '1',
                 initDate: new Date('2024-07-15T10:00:00.000Z'),
@@ -42,14 +43,15 @@ describe("MyReservations Component", () => {
                 totalPrice: 15,
                 isPaid: true
             },
-            { _id: 'res2',
+            {
+                _id: 'res2',
                 userId: '123',
                 facilityId: '2',
-                initDate: new Date('2024-07-20T15:00:00.000Z'), 
+                initDate: new Date('2024-07-20T15:00:00.000Z'),
                 endDate: new Date('2024-07-20T16:00:00.000Z'),
                 totalPrice: 20,
                 isPaid: false
-             }
+            }
         ]);
         mockFacilitiesAndReservationsContext.deleteReservation = jest.fn().mockImplementation(async () => {
             await new Promise(resolve => setTimeout(resolve, 50));
@@ -109,14 +111,14 @@ describe("MyReservations Component", () => {
 
     it("updates reservation list after successful deletion", async () => {
         mockFacilitiesAndReservationsContext.getAllReservations.mockResolvedValue([{
-                _id: 'res2',
-                userId: '123',
-                facilityId: '2',
-                initDate: new Date('2024-07-20T15:00:00.000Z'),
-                endDate: new Date('2024-07-20T16:00:00.000Z'),
-                totalPrice: 20,
-                isPaid: true
-            }
+            _id: 'res2',
+            userId: '123',
+            facilityId: '2',
+            initDate: new Date('2024-07-20T15:00:00.000Z'),
+            endDate: new Date('2024-07-20T16:00:00.000Z'),
+            totalPrice: 20,
+            isPaid: true
+        }
         ]);
         render(<MyReservations />);
         let deleteButtons;
@@ -184,6 +186,55 @@ describe("MyReservations Component", () => {
         await waitFor(() => {
             expect(mockFacilitiesAndReservationsContext.deleteReservation).toHaveBeenCalledWith('res1');
             expect(toast.error).toHaveBeenCalledWith('Error al eliminar la reserva. Inténtalo de nuevo.'); // Verifica que se muestra el toast de error
+        });
+    });
+
+    describe("Pagination", () => {
+        it("renders pagination buttons correctly", async () => {
+            render(<MyReservations />);
+            await waitFor(() => {
+                expect(screen.getByRole("button", { name: /anterior/i })).toBeInTheDocument();
+                expect(screen.getByRole("button", { name: /siguiente/i })).toBeInTheDocument();
+            });
+        });
+
+        it("disables 'Anterior' button on first page", async () => {
+            render(<MyReservations />);
+            await waitFor(() => {
+                expect(screen.getByRole("button", { name: /anterior/i })).toBeDisabled();
+            });
+        });
+
+        it("disables 'Siguiente' button on last page", async () => {
+            mockFacilitiesAndReservationsContext.getAllReservations.mockResolvedValue(new Array(5).fill({}).map((_, index) => ({
+                _id: `res${index}`, userId: '123', facilityId: '1', initDate: new Date(), endDate: new Date(), totalPrice: 15, isPaid: true
+            })));
+            render(<MyReservations />);
+            await waitFor(() => {
+                expect(screen.getByRole("button", { name: /siguiente/i })).toBeDisabled();
+            });
+        });
+
+        it("enables 'Anterior' button when not on first page", async () => {
+            mockFacilitiesAndReservationsContext.getAllReservations.mockResolvedValue(new Array(10).fill({}).map((_, index) => ({
+                _id: `res${index}`, userId: '123', facilityId: '1', initDate: new Date(), endDate: new Date(), totalPrice: 15, isPaid: true
+            })));
+            render(<MyReservations />);
+            await waitFor(() => {
+                fireEvent.click(screen.getByRole("button", { name: /siguiente/i }));
+                expect(screen.getByRole("button", { name: /anterior/i })).not.toBeDisabled();
+            });
+        });
+
+        it("enables 'Siguiente' button when not on last page", async () => {
+            mockFacilitiesAndReservationsContext.getAllReservations.mockResolvedValue(new Array(20).fill({}).map((_, index) => ({
+                _id: `res${index}`, userId: '123', facilityId: '1', initDate: new Date(), endDate: new Date(), totalPrice: 15, isPaid: true
+            })));
+            render(<MyReservations />);
+            await waitFor(() => {
+                fireEvent.click(screen.getByRole("button", { name: /siguiente/i }));
+                expect(screen.getByRole("button", { name: /siguiente/i })).not.toBeDisabled();
+            });
         });
     });
 });


### PR DESCRIPTION
### SUMMARY
Trello ticket: https://trello.com/c/ewa1X529/129-dpurjc-047-paginaci%C3%B3n-en-reservas

> Se necesita introducir una nueva funcionalidad de paginación en reservas y adminReservas para no sobrecargar la página, tanto visualmente como en memoria.

### Expected behaviour

No debería haber un scroll casi infinito, habiendo tantas reservas.
Debe mostarse una paginación.

### Before Screenshots
![image](https://github.com/user-attachments/assets/782d95c0-fa96-4157-a768-2689fd6c0fe2)

![image](https://github.com/user-attachments/assets/00177b9e-5f0e-4ae3-9267-5b35f0bf68e1)


### After Screenshots
![image](https://github.com/user-attachments/assets/4a41474d-7b06-4664-afb5-bd813d3f583f)
![image](https://github.com/user-attachments/assets/7b805480-10fc-4eec-99fb-38b3275f10ac)

