### PR TITLE
[DPURJC-051] - La cookie debe gestionarse con session

### DIFF
--- a/backend/app/routes/user.js
+++ b/backend/app/routes/user.js
@@ -4,31 +4,26 @@ const controller = require('../controllers/user')
 const router = express.Router()
 const path = 'users'
 
-// Ruta GET users
 router.get(`/${path}`, controller.getData);
 
-// Ruta GET user by id
+// Login cookie
+router.get(`/${path}/session`, controller.getSessionUser);
+
 router.get(`/${path}/:id`, controller.getOne);
 
-// Ruta POST register
 router.post(`/${path}/register`, controller.register);
 
-// Ruta POST login
 router.post(`/${path}/login`, controller.login);
 
-// Ruta POST logout
 router.post(`/${path}/logout`, controller.logout);
 
-// Ruta PUT user
 router.put(`/${path}/:id`, controller.updateOne);
 
-// Ruta PUT user edit password and profile
 router.put(`/${path}/:id/profile`, controller.updatePasswordAndName);
 
-// Ruta DELETE user
 router.delete(`/${path}/:id`, controller.deleteOne);
 
-// Nueva ruta para obtener el email del admin desde .env
+// Checks admin user email from .env
 router.post(`/${path}/check-admin`, controller.checkIfAdmin );
 
 module.exports = router;

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -2,8 +2,6 @@ const mongoose = require('mongoose');
 
 jest.setTimeout(20000); // 20 seconds timeout for tests
 
-console.log('🔍 URI de test:', process.env.MONGO_ATLAS_URI_TEST);
-
 beforeAll(async () => {
   await mongoose.connect(process.env.MONGO_ATLAS_URI_TEST, {
     useNewUrlParser: true,

--- a/backend/tests/user.test.js
+++ b/backend/tests/user.test.js
@@ -37,12 +37,19 @@ describe('🧪 Auth tests', () => {
 
   it('debería loguear correctamente con el usuario', async () => {
     await request(app).post('/users/register').send(userData);
-    const res = await request(app).post('/users/login').send({
+  
+    const agent = request.agent(app); // Mantain session between requests
+  
+    const loginRes = await agent.post('/users/login').send({
       email: userData.email,
       password: userData.password
     });
-    expect(res.statusCode).toBe(200);
-    expect(res.body.email).toBe(userData.email);
+  
+    expect(loginRes.statusCode).toBe(200);
+  
+    const sessionRes = await agent.get('/users/session');
+    expect(sessionRes.statusCode).toBe(200);
+    expect(sessionRes.body.email).toBe(userData.email);
   });
 
   it('debería obtener un usuario por ID', async () => {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "bson": "^6.10.1",
         "dotenv": "^16.4.5",
-        "js-cookie": "^3.0.5",
         "react": "18.3.1",
         "react-datepicker": "^6.9.0",
         "react-dom": "18.3.1",
@@ -7718,15 +7717,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "bson": "^6.10.1",
     "dotenv": "^16.4.5",
-    "js-cookie": "^3.0.5",
     "react": "18.3.1",
     "react-datepicker": "^6.9.0",
     "react-dom": "18.3.1",

--- a/frontend/src/utils/mocks.js
+++ b/frontend/src/utils/mocks.js
@@ -4,9 +4,6 @@ export const mockAuthContext = {
     setUser: jest.fn((newUser) => {
         mockAuthContext.user = newUser;
     }),
-    updateUserAndCookie: jest.fn((updatedUser) => {
-        mockAuthContext.user = updatedUser;
-    }),
     login: jest.fn().mockImplementation(async (credentials, callback) => {
         const mockUser = { _id: "123", email: credentials.email, role: "admin" };
         mockAuthContext.user = mockUser;
@@ -25,14 +22,14 @@ export const mockAuthContext = {
     updateUser: jest.fn().mockImplementation(async (id, data) => {
         if (mockAuthContext.user?._id === id) {
             const updated = { ...mockAuthContext.user, ...data };
-            mockAuthContext.updateUserAndCookie(updated);
+            mockAuthContext.user = updated;
             return updated;
         }
         return { _id: id, ...data };
     }),
     updatePasswordAndName: jest.fn().mockImplementation(async (id, currentPassword, newPassword, name) => {
         const updated = { ...mockAuthContext.user, name };
-        mockAuthContext.updateUserAndCookie(updated);
+        mockAuthContext.user = updated;
         return updated;
     }),
     deleteUser: jest.fn().mockResolvedValue(true),

--- a/frontend/src/views/profile/seeProfile/SeeProfile.jsx
+++ b/frontend/src/views/profile/seeProfile/SeeProfile.jsx
@@ -7,7 +7,7 @@ import { useFacilitiesAndReservations } from "../../../context/FacilitiesAndRese
 import BackButton from "../../../components/backButton/BackButton";
 
 const SeeProfile = () => {
-    const { user, updateUserAndCookie, isAdmin, logout, deleteUser, updatePasswordAndName } = useAuth();
+    const { user, isAdmin, logout, deleteUser, updatePasswordAndName } = useAuth();
     const { reservations, deleteReservation } = useFacilitiesAndReservations();
     const navigate = useNavigate();
     const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);

--- a/frontend/src/views/profile/seeProfile/SeeProfile.test.js
+++ b/frontend/src/views/profile/seeProfile/SeeProfile.test.js
@@ -39,7 +39,6 @@ describe("SeeProfile Component", () => {
         mockAuthContext.updateUser.mockResolvedValue({ status: 200, data: { message: 'Profile updated' } });
         mockFacilitiesAndReservationsContext.reservations = [];
         mockFacilitiesAndReservationsContext.deleteReservation.mockResolvedValue({ status: 200 });
-        mockAuthContext.updateUserAndCookie = jest.fn();
     });
 
     it("renders component with user data", () => {
@@ -80,7 +79,7 @@ describe("SeeProfile Component", () => {
         expect(passwordInput.value).toBe("newPass123");
     });
 
-    it("calls updatePasswordAndName and updateUserAndCookie on valid edit form submission", async () => {
+    it("calls updatePasswordAndName on valid edit form submission", async () => {
         render(<SeeProfile />);
         const editButton = screen.getByRole("button", { name: /editar perfil/i });
         fireEvent.click(editButton);
@@ -97,7 +96,6 @@ describe("SeeProfile Component", () => {
 
         await waitFor(() => {
             expect(mockAuthContext.updatePasswordAndName).toHaveBeenCalledWith("123", "actualPass", "updatedPass", "Updated Name");
-            expect(mockAuthContext.updateUserAndCookie).toHaveBeenCalledWith(expect.objectContaining({ name: "Updated Name" }));
             expect(toast.success).toHaveBeenCalledWith("Perfil actualizado con éxito.");
         });
     });


### PR DESCRIPTION
### SUMMARY
Trello ticket: https://trello.com/c/lV359DHk/138-dpurjc-051-la-cookie-debe-gestionarse-con-session

> La cookie no debería contener todos los datos del user y menos la password (aunque sea encriptada).
> La lógica es que toda la lógica se controle desde el backend. De esta manera evitamos ataques.

### Expected behaviour

Ahora en las cookies se debe poder ver una id de sesión, no los datos completos del user.

### Before Screenshots
Por seguridad no adjunto captura de la cookie en la versión anterior.
Aparecían todos los datos del user en la cookie.

### After Screenshots
![image](https://github.com/user-attachments/assets/8a5d1df6-9885-431b-bbf7-cdaae933d0c9)

