### PR TITLE
[hotfix-DPURJC] - Fix app title name and white section below footer

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/x-icon" href="/src/assets/logo_urjc_deportes.jpg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>DeportesURJC</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -283,3 +283,16 @@ button.navbar-button {
 table {
   margin: 20px 0;
 }
+
+/* Fix para la sección de notificaciones de Sonner - que tenga el mismo fondo que el footer */
+section[aria-label*="Notifications"] {
+  background-color: var(--secondary-color) !important; /* Mismo color que el footer (negro) */
+  min-height: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+/* También aplicar estilos a los contenedores de Sonner cuando no hay notificaciones */
+[data-sonner-toaster] {
+  background-color: transparent !important;
+}


### PR DESCRIPTION
### SUMMARY
Trello ticket: https://trello.com/...

> Fix styles from sonner notifications, there is a white section below footer.
> Also, change app title and app logo.

### Expected behaviour
- There should not be a white section below footer.
- Should show new App title and app logo.


### Before Screenshots
<img width="845" height="230" alt="image" src="https://github.com/user-attachments/assets/1ff4a8b8-db8a-4cbc-af43-7c39d0f68938" />
<img width="171" height="31" alt="image" src="https://github.com/user-attachments/assets/432f2c78-c019-45b1-a59f-6c31afc22f92" />


### After Screenshots
<img width="1918" height="574" alt="image" src="https://github.com/user-attachments/assets/c6caa774-cf3e-45ff-952c-47813ceb3c42" />
<img width="181" height="41" alt="image" src="https://github.com/user-attachments/assets/0f045eb3-08bc-41db-8594-a6a3ebac2e01" />

